### PR TITLE
画像投稿機能の実装

### DIFF
--- a/app/assets/stylesheets/modules/new.scss
+++ b/app/assets/stylesheets/modules/new.scss
@@ -52,29 +52,35 @@
     &__text{
       padding: 0 12px;
     }
-    &__image-field{
-      width: 660px;
-      height: 160px;
-      margin: 16px auto;
-      background-color: #eee;
-      border: 1px dashed #ccc;
+    &__image-box {
       display: flex;
-      justify-content: center;
-      align-items: center;
-      font-size: 12px;
-      text-align: center;
-      position: relative;
-      cursor: pointer;
-      .fa-camera{
-        position: absolute;
-        top: 40px;
-        font-size: 20px;
+      &____previews {
+        display: block;
       }
-      #item_images_image {
-        display: none;
-      }
-      &__text{
-        padding-top: 20px;
+      &__image-field{
+        width: 660px;
+        height: 160px;
+        margin: 16px auto;
+        background-color: #eee;
+        border: 1px dashed #ccc;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 12px;
+        text-align: center;
+        position: relative;
+        cursor: pointer;
+        .fa-camera{
+          position: absolute;
+          top: 40px;
+          font-size: 20px;
+        }
+        &__file {
+          display: none;
+        }
+        &__text{
+          padding-top: 20px;
+        }
       }
     }
     &__input-text{

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,16 +1,2 @@
 class ImagesController < ApplicationController
-  def new
-    @image = Image.new
-  end
-
-  def create
-    @image = Image.new(image_params)
-    @image.save
-    redirect_to root_path
-  end
-
-  private
-  def image_params
-    params.require(:image).permit(:image)
-  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,15 +5,28 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
+    @item.images.new
+    # @item = Item.includes(:images).order('created_at DESC')
   end
 
   def create
     @item = Item.new(item_params)
-    if @item.save
+    # if @item.images.length == 1..10 && @item.save
+    if  @item.valid? && @item.images.length == 1..10
+      @item.save
       redirect_to @item
     else
       render :new
     end
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
   end
 
   def show
@@ -24,7 +37,7 @@ class ItemsController < ApplicationController
 
   private
   def item_params
-    params.require(:item).permit(:name, :introduction, :condition, :area_id, :size, :price, :preparation_day, :postage)
-    # params.requier(:item).permit(:name, :introduction, :condition, :area_id, :size, :price, :preparation_day, :postage, :category_id, :brand_id).merge(seller_id: current_user.id)
+    params.require(:item).permit(:name, :introduction, :condition, :area_id, :size, :price, :preparation_day, :postage, images_attributes: [:image])
+    # (:category_id, :brand_id).merge(seller_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,14 +6,11 @@ class ItemsController < ApplicationController
   def new
     @item = Item.new
     @item.images.new
-    # @item = Item.includes(:images).order('created_at DESC')
   end
 
   def create
     @item = Item.new(item_params)
-    # if @item.images.length == 1..10 && @item.save
-    if  @item.valid? && @item.images.length == 1..10
-      @item.save
+    if @item.save
       redirect_to @item
     else
       render :new
@@ -38,6 +35,5 @@ class ItemsController < ApplicationController
   private
   def item_params
     params.require(:item).permit(:name, :introduction, :condition, :area_id, :size, :price, :preparation_day, :postage, images_attributes: [:image])
-    # (:category_id, :brand_id).merge(seller_id: current_user.id)
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,7 +1,5 @@
 class Image < ApplicationRecord
   belongs_to :item
 
-  validates :image, presence: true
-
   mount_uploader :image, ImageUploader
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,5 +1,5 @@
 class Image < ApplicationRecord
-  # belongs_to :item
+  belongs_to :item
 
   validates :image, presence: true
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,12 +1,8 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :area
-  # has_many :commnets, dependent: :destroy
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true
-  # belongs_to :category
-  # belongs_to :brand
-  # belongs_to :user
 
   with_options presence: true do
     validates :name, length: { minimum: 1, maximum: 40 }
@@ -16,5 +12,8 @@ class Item < ApplicationRecord
     validates :price, numericality: { only_integer: true , greater_than: 299, less_than: 10000000 }
     validates :preparation_day
     validates :postage
+    validates :images
   end
+  validates_associated :images
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,8 +1,9 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :area
-  # has_many   :commnets, dependent: :destroy
-  # has_many   :images,   dependent: :destroy
+  # has_many :commnets, dependent: :destroy
+  has_many :images, dependent: :destroy
+  accepts_nested_attributes_for :images, allow_destroy: true
   # belongs_to :category
   # belongs_to :brand
   # belongs_to :user

--- a/app/views/images/new.html.haml
+++ b/app/views/images/new.html.haml
@@ -1,4 +1,0 @@
-= form_with model: @image, local: true do |f|
-  = f.file_field :image
-  = f.submit
-  -# 1~3行目は画像投稿検証のための記述

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -5,14 +5,19 @@
       %span{class: "require"} 必須
     .new-wrapper__main__text
       最大10枚までアップロードできます
-    = f.label :image, class: "new-wrapper__main__image-field" do
-      = icon( 'fa', 'camera')
-      = f.fields_for :images do |i|
-        = i.file_field :image, size: "100x100", class: "input-box__image__file"
-      .new-wrapper__main__image-field__text
-        ドラッグアンドドロップ
-        %br
-        またはクリックしてファイルをアップロード
+    .new-wrapper__main__image-box
+      -# .new-wrapper__main__image-box__previews
+      -#   - if @item.persisted?
+      -#     = @item.images.each do |image|
+      -#       = image_tag image.image.url, size: "100x100"
+      %label{class: "new-wrapper__main__image-box__image-field"}
+        = icon( 'fa', 'camera')
+        = f.fields_for :images do |i|
+          = i.file_field :image, class: "new-wrapper__main__image-box__image-field__file"
+        .new-wrapper__main__image-box__image-field__text
+          ドラッグアンドドロップ
+          %br
+          またはクリックしてファイルをアップロード
   .new-wrapper__main
     .new-wrapper__main__title
       商品名

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -6,10 +6,6 @@
     .new-wrapper__main__text
       最大10枚までアップロードできます
     .new-wrapper__main__image-box
-      -# .new-wrapper__main__image-box__previews
-      -#   - if @item.persisted?
-      -#     = @item.images.each do |image|
-      -#       = image_tag image.image.url, size: "100x100"
       %label{class: "new-wrapper__main__image-box__image-field"}
         = icon( 'fa', 'camera')
         = f.fields_for :images do |i|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,10 +8,10 @@ Rails.application.routes.draw do
     collection do
     get 'confirm'
     end
-    # resources :images, only: [ :new, :create] 
+    resources :images, only: [:new, :create] 
   end
 
-  resources :users, only: [:new, :show, :destroy] do
+  resources :users, only: [:new, :show] do
     resources :cards, only: [:new]
     collection do
       get "new_address"

--- a/db/migrate/20200512100424_create_images.rb
+++ b/db/migrate/20200512100424_create_images.rb
@@ -1,8 +1,8 @@
 class CreateImages < ActiveRecord::Migration[5.2]
   def change
     create_table :images do |t|
+      t.references :item,  null: false, foreign_key: true
       t.string     :image, null: false
-      # t.references :item,  null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_11_071651) do
+ActiveRecord::Schema.define(version: 2020_05_12_100424) do
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "item_id", null: false
     t.string "image", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_images_on_item_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -52,4 +54,5 @@ ActiveRecord::Schema.define(version: 2020_05_11_071651) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "images", "items"
 end


### PR DESCRIPTION
## What
【サーバサイド】商品出品機能のカード切り分けを実施。
画像投稿機能の実装。
画像が0枚のときは投稿できないように制限実施。
複数枚画像の同時の投稿。
非同期通信は後ほど実装予定。

## Why
画像の投稿機の実装のため。
また、商品詳細表示・一覧表示を実装するため。

https://i.gyazo.com/90f40fcaf373afcc18e7e8c4705e39d9.mp4