### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ gem 'carrierwave'
 gem 'mini_magick'
 gem 'fog-aws'
 gem 'active_hash'
+gem 'rails-i18n'
+gem 'enum_help'
 
 group :production do
   gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.9.0)
     erubis (2.7.0)
     excon (0.73.0)
@@ -218,6 +220,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.4.2)
       actionpack (= 5.2.4.2)
       activesupport (= 5.2.4.2)
@@ -317,6 +322,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  enum_help
   fog-aws
   font-awesome-sass
   haml-rails
@@ -327,6 +333,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-i18n
   sass-rails (~> 5.0)
   selenium-webdriver
   spring

--- a/app/assets/stylesheets/modules/_top.scss
+++ b/app/assets/stylesheets/modules/_top.scss
@@ -210,9 +210,6 @@ img.google-play {
     font-weight: bold;
     text-align: center;
   }
-  // &__box__list {
-  //   display: inline-block;
-  // }
   &__box__list__item a {
     text-decoration: none;
   }

--- a/app/assets/stylesheets/modules/_top.scss
+++ b/app/assets/stylesheets/modules/_top.scss
@@ -210,6 +210,9 @@ img.google-play {
     font-weight: bold;
     text-align: center;
   }
+  // &__box__list {
+  //   display: inline-block;
+  // }
   &__box__list__item a {
     text-decoration: none;
   }
@@ -260,3 +263,7 @@ img.google-play {
     }
   }
 }
+
+// .flex {
+//   display: flex;
+// }

--- a/app/assets/stylesheets/modules/_top.scss
+++ b/app/assets/stylesheets/modules/_top.scss
@@ -263,7 +263,3 @@ img.google-play {
     }
   }
 }
-
-// .flex {
-//   display: flex;
-// }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,10 @@
 class ItemsController < ApplicationController
 
   def index
+    @items = Item.all.order(created_at: :desc)
+    # @items = Item.includes(:image).order(created_at: :DESC)
+    # @items = Item.all.order(created_at: :desc)
+    # @images = Image.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,9 +2,6 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.all.order(created_at: :desc)
-    # @items = Item.includes(:image).order(created_at: :DESC)
-    # @items = Item.all.order(created_at: :desc)
-    # @images = Image.all
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,5 +15,7 @@ class Item < ApplicationRecord
     validates :images
   end
   validates_associated :images
+  enum preparation_day: [:short, :middle, :long]
+  enum postage: [:including, :noincluding]
 
 end

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -14,6 +14,12 @@
           ドラッグアンドドロップ
           %br
           またはクリックしてファイルをアップロード
+        = f.fields_for :images do |i|
+          = i.file_field :image, class: "new-wrapper__main__image-box__image-field__file"
+        .new-wrapper__main__image-box__image-field__text
+          ドラッグアンドドロップ
+          %br
+          またはクリックしてファイルをアップロード
   .new-wrapper__main
     .new-wrapper__main__title
       商品名

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -48,7 +48,7 @@
     .new-wrapper__main__title
       配送料の負担
       %span{class: "require"} 必須
-    = f.select :postage, [["送料込み（出品者負担）", "1"], ["着払い（購入者負担）", "2"]], include_blank: "選択して下さい"
+    = f.select :postage, Item.postages_i18n.invert {}, prompt: "選択してください"
     .new-wrapper__main__title.spacing
       発送元の地域
       %span{class: "require"} 必須
@@ -56,7 +56,7 @@
     .new-wrapper__main__title.spacing
       発送までの日数
       %span{class: "require"} 必須
-    = f.select :preparation_day, [["1~2日で発送", "1"], ["2~3日で発送", "2"], ["4~7日で発送", "3"]], include_blank: "選択して下さい"
+    = f.select :preparation_day, Item.preparation_days_i18n.invert {}, prompt: "選択してください"
   .new-wrapper__main
     .new-wrapper__main__subtitle
       価格（¥300〜9,999,999）

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -103,20 +103,37 @@
             新規投稿商品
       .pickup-item__box__list
         .pickup-item__box__list__item
-          - for i in 1..3
-            %a{href: "/products/3"}
-              %figure.pickup-item__box__list__item__image
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"
-              .pickup-item__box__list__item__body
-                %h3.pickup-item__box__list__item__body__name
-                  item1
-                .pickup-item__box__list__item__body__detail
-                  %ul
-                    %li
-                      30000円
-                    %li
-                      %i.fa.fa-star
-                      0
-                  %p
-                    (税込)
+          - @items.each do |item|
+            = link_to item_path(item.id) do
+              - item.images.each do |image|
+                %figure.pickup-item__box__list__item__image
+                  = image_tag image.image.url
+                .pickup-item__box__list__item__body
+                  %h3.pickup-item__box__list__item__body__name
+                    = item.name
+                  .pickup-item__box__list__item__body__detail
+                    %ul
+                      %li
+                        = item.price
+                      %li
+                        %i.fa.fa-star
+                        0
+                    %p
+                      (税込)
+          -# - for i in 1..3
+          -#   %a{href: "/products/3"}
+          -#     %figure.pickup-item__box__list__item__image
+          -#       = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"
+          -#     .pickup-item__box__list__item__body
+          -#       %h3.pickup-item__box__list__item__body__name
+          -#         item1
+          -#       .pickup-item__box__list__item__body__detail
+          -#         %ul
+          -#           %li
+          -#             30000円
+          -#           %li
+          -#             %i.fa.fa-star
+          -#             0
+          -#         %p
+          -#           (税込)
 = render partial: "shared/footer"

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -103,21 +103,22 @@
             新規投稿商品
       .pickup-item__box__list
         .pickup-item__box__list__item
-          - @items.each do |item|
+          - @items[0..2].each do |item|
             = link_to item_path(item.id) do
-              - item.images.each do |image|
-                %figure.pickup-item__box__list__item__image
-                  = image_tag image.image.url
-                .pickup-item__box__list__item__body
-                  %h3.pickup-item__box__list__item__body__name
-                    = item.name
-                  .pickup-item__box__list__item__body__detail
-                    %ul
-                      %li
-                        = item.price
-                      %li
-                        %i.fa.fa-star
-                        0
-                    %p
-                      (税込)
+              - item.images.each.with_index(1) do |image,i|
+                - if i == 1
+                  %figure.pickup-item__box__list__item__image
+                    = image_tag image.image.url
+                  .pickup-item__box__list__item__body
+                    %h3.pickup-item__box__list__item__body__name
+                      = item.name
+                    .pickup-item__box__list__item__body__detail
+                      %ul
+                        %li
+                          = item.price
+                        %li
+                          %i.fa.fa-star
+                          0
+                      %p
+                        (税込)
 = render partial: "shared/footer"

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -120,20 +120,4 @@
                         0
                     %p
                       (税込)
-          -# - for i in 1..3
-          -#   %a{href: "/products/3"}
-          -#     %figure.pickup-item__box__list__item__image
-          -#       = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"
-          -#     .pickup-item__box__list__item__body
-          -#       %h3.pickup-item__box__list__item__body__name
-          -#         item1
-          -#       .pickup-item__box__list__item__body__detail
-          -#         %ul
-          -#           %li
-          -#             30000円
-          -#           %li
-          -#             %i.fa.fa-star
-          -#             0
-          -#         %p
-          -#           (税込)
 = render partial: "shared/footer"

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -105,20 +105,18 @@
         .pickup-item__box__list__item
           - @items[0..2].each do |item|
             = link_to item_path(item.id) do
-              - item.images.each.with_index(1) do |image,i|
-                - if i == 1
-                  %figure.pickup-item__box__list__item__image
-                    = image_tag image.image.url
-                  .pickup-item__box__list__item__body
-                    %h3.pickup-item__box__list__item__body__name
-                      = item.name
-                    .pickup-item__box__list__item__body__detail
-                      %ul
-                        %li
-                          = item.price
-                        %li
-                          %i.fa.fa-star
-                          0
-                      %p
-                        (税込)
+              %figure.pickup-item__box__list__item__image
+                = image_tag item.images.first.image.url
+              .pickup-item__box__list__item__body
+                %h3.pickup-item__box__list__item__body__name
+                  = item.name
+                .pickup-item__box__list__item__body__detail
+                  %ul
+                    %li
+                      = item.price
+                    %li
+                      %i.fa.fa-star
+                      0
+                  %p
+                    (税込)
 = render partial: "shared/footer"

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module FreemarketSample74c
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  enums:
+    item:
+      preparation_day:
+        short: "1~2日で発送"
+        middle: "2~3日で発送"
+        long: "4~7日で発送"
+      postage:
+        including: "送料込み（出品者負担）"
+        noincluding: "着払い（購入者負担）"


### PR DESCRIPTION
# What
- 商品一覧表示の実装（カテゴリー別、ブランド別、売り切れ判別は後日実装）
- enumの導入

[top-page.pdf](https://github.com/yoshi5525/freemarket_sample_74c/files/4627910/top-page.pdf)

# Why
- DBに登録されている商品をトップページに表示するため
- 配送料と発送までの日数をintegerからstringに変換（翻訳）するため