### PR TITLE
画像のバリデーション追加など5項目修正

### DIFF
--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -24,21 +24,22 @@ $(function(){
     const html = `<div class="new-wrapper__main__image-box__image-label__image-field" id="image-field-second">
                     <i class="fas fa-camera"></i>
                     <div class="new-wrapper__main__imagde-box__image-label__image-field__text">
-                      ドラッグアンドドロップ
-                      <br>
-                      またはクリックしてファイルをアップロード
+                      クリックしてファイルをアップロード
                     </div>
                   </div>`;
     return html;
   }
 
   const fileIndex = [0,1,2,3,4,5,6,7,8,9];
+  if ($('.previews__image').length <= $('.js-file').length-2) {
+    $('.js-file_group').remove();
+  }
   lastIndex = $('.js-file_group:last').data('index');
   fileIndex.splice(0, lastIndex);
 
   $('.hidden-destroy').hide();
 
-  if ($('.js-file').length == 0) {
+  if ($('.js-file').length == 0  && ($('.previews__image').length == 0)) {
     $("#image-label").attr("for", `item_images_attributes_${fileIndex[0]}_image`);
     $('.new-wrapper__main__image-box').append(buildFileField(fileIndex[0]));
   };
@@ -107,9 +108,5 @@ $(function(){
     } else {
       $("#image-field-second").css("width", 650-($('.previews__image').length-5)*130);
     }
-    if ($('.js-file').length - $('.previews__image').length == 0) {
-      $(".new-wrapper__main__image-box").append(buildFileField(targetIndex));
-      $("#image-label").attr("for", `item_images_attributes_${targetIndex}_image`);
-    };
   });
 });

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,13 +31,8 @@ class ItemsController < ApplicationController
     grandchild_category = @item.category
     child_category = grandchild_category.parent
 
-    @category_parent_array = []
     @category_parent_array = Category.where(ancestry: nil)
-
-    @category_children_array = []
     @category_children_array = Category.where(ancestry: child_category.ancestry)
-
-    @category_grandchildren_array = []
     @category_grandchildren_array = Category.where(ancestry: grandchild_category.ancestry)
   end
 
@@ -48,13 +43,8 @@ class ItemsController < ApplicationController
       grandchild_category = @item.category
       child_category = grandchild_category.parent
 
-      @category_parent_array = []
       @category_parent_array = Category.where(ancestry: nil)
-
-      @category_children_array = []
       @category_children_array = Category.where(ancestry: child_category.ancestry)
-
-      @category_grandchildren_array = []
       @category_grandchildren_array = Category.where(ancestry: grandchild_category.ancestry)
       render :edit
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
   before_action :set_item, only:[:edit, :update, :destroy, :show, :confirm, :pay]
-  before_action :move_to_index, except:[:index, :show]
+  before_action :move_to_index, except:[:index, :show, :confirm]
+  before_action :move_to_session, only:[:confirm]
+  before_action :sold_check, only:[:confirm]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -16,6 +18,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to @item
     else
+      @item.images.new
       render :new
     end
   end
@@ -42,6 +45,17 @@ class ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to @item
     else
+      grandchild_category = @item.category
+      child_category = grandchild_category.parent
+
+      @category_parent_array = []
+      @category_parent_array = Category.where(ancestry: nil)
+
+      @category_children_array = []
+      @category_children_array = Category.where(ancestry: child_category.ancestry)
+
+      @category_grandchildren_array = []
+      @category_grandchildren_array = Category.where(ancestry: grandchild_category.ancestry)
       render :edit
     end
   end
@@ -55,6 +69,9 @@ class ItemsController < ApplicationController
   end
 
   def confirm
+    if current_user.id == @item.seller_id
+      redirect_to root_path
+    end
     Payjp.api_key = Rails.application.credentials.payjp[:secret_key]
     if Card.where(user_id: current_user.id).blank?
       flash[:alert] = "クレジットカードを登録してください"
@@ -122,6 +139,19 @@ class ItemsController < ApplicationController
 
   def move_to_index
     redirect_to action: :index unless user_signed_in?
+  end
+
+  def move_to_session
+    unless user_signed_in?
+      redirect_to new_user_session_path
+      flash[:alert] = "ログインしてください"
+    end
+  end
+
+  def sold_check
+    if @item.buyer_id != nil
+      redirect_to root_path
+    end
   end
 end
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,5 +1,4 @@
 class Image < ApplicationRecord
   belongs_to :item
-
   mount_uploader :image, ImageUploader
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,7 @@ class Item < ApplicationRecord
   has_many :images, dependent: :destroy
   belongs_to :category
   accepts_nested_attributes_for :images, allow_destroy: true
-  
+
   validates :name, length: { minimum: 1, maximum: 40 }, presence: true
   validates :introduction, length: { minimum: 1, maximum: 1000 }, presence: true
   validates :condition, presence: true
@@ -16,7 +16,7 @@ class Item < ApplicationRecord
   validates :postage, presence: true
   validates :status, presence: true
   validates :seller_id, presence: true
-  validates_associated :images
+  validates :images, presence: true
 
   enum preparation_day: [:short, :middle, :long]
   enum postage: [:including, :noincluding]

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -1,6 +1,6 @@
 #request{action: request.path}
 = form_for @item do |f|
-  = render 'layouts/error_messages', model: f.object 
+  = render 'layouts/error_messages', model: f.object
   .new-wrapper__main
     .new-wrapper__main__title
       出品画像
@@ -19,9 +19,7 @@
             .new-wrapper__main__image-box__image-label__image-field
               = icon( 'fa', 'camera')
               .new-wrapper__main__imagde-box__image-label__image-field__text
-                ドラッグアンドドロップ
-                %br
-                またはクリックしてファイルをアップロード
+                クリックしてファイルをアップロード
             = f.fields_for :images do |i|
               .js-file_group{data: {index: i.index}}
                 = i.file_field :image, class: "js-file"
@@ -45,23 +43,17 @@
             .new-wrapper__main__image-box__image-label__image-field{ style: "display: none"}
               = icon( 'fa', 'camera')
               .new-wrapper__main__imagde-box__image-label__image-field__text
-                ドラッグアンドドロップ
-                %br
-                またはクリックしてファイルをアップロード
+                クリックしてファイルをアップロード
             - if 5 <= @item.images.length && @item.images.length < 10
               .new-wrapper__main__image-box__image-label__image-field{ id: "image-field-second"}
                 = icon( 'fa', 'camera')
                 .new-wrapper__main__imagde-box__image-label__image-field__text
-                  ドラッグアンドドロップ
-                  %br
-                  またはクリックしてファイルをアップロード
+                  クリックしてファイルをアップロード
             - else
               .new-wrapper__main__image-box__image-label__image-field{ id: "image-field-second", style: "display: none;"}
                 = icon( 'fa', 'camera')
                 .new-wrapper__main__imagde-box__image-label__image-field__text
-                  ドラッグアンドドロップ
-                  %br
-                  またはクリックしてファイルをアップロード
+                  クリックしてファイルをアップロード
             = f.fields_for :images do |i|
               .js-file_group{data: {index: i.index}}
                 = i.file_field :image, class: "js-file"
@@ -76,9 +68,7 @@
           .new-wrapper__main__image-box__image-label__image-field
             = icon( 'fa', 'camera')
             .new-wrapper__main__imagde-box__image-label__image-field__text
-              ドラッグアンドドロップ
-              %br
-              またはクリックしてファイルをアップロード
+              クリックしてファイルをアップロード
           = f.fields_for :images do |i|
             .js-file_group{data: {index: i.index}}
               = i.file_field :image, class: "js-file"
@@ -102,8 +92,7 @@
     .new-wrapper__main__title
       カテゴリー
       %span{class: "require"} 必須
-
-    - if @item.category.present?
+    - if @item.persisted?
       #category-preview
         = f.select :category, options_for_select( @category_parent_array.map{|c|[c[:name], c[:id], {}]}, @item.category.parent.parent.id), {}, {class: 'new-wrapper__main__input-select select-parent', id: 'select-parent', style: 'margin-bottom: 10px;'}
         = f.select :category, options_for_select( @category_children_array.map{|c|[c[:name], c[:id], {}]}, @item.category.parent.id), {}, {class: 'new-wrapper__main__input-select select-child', id: 'select-parent', style: 'margin-bottom: 10px;'}

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -39,43 +39,43 @@ describe Item, type: :model do
         item.valid?
         expect(item.errors[:category]).to include("を入力してください")
       end
-      
+
       it "conditionがない場合は投稿できないこと" do
         item = build(:item, category_id: category[:id], condition: nil)
         item.valid?
         expect(item.errors[:condition]).to include("を入力してください")
       end
-      
+
       it "area_idがない場合は投稿できないこと" do
         item = build(:item, category_id: category[:id], area_id: nil)
         item.valid?
         expect(item.errors[:area]).to include("を入力してください")
       end
-      
+
       it "priceがない場合は投稿できないこと" do
         item = build(:item, category_id: category[:id], price: nil)
         item.valid?
         expect(item.errors[:price]).to include("は数値で入力してください", "を入力してください")
       end
-      
+
       it "preparation_dayがない場合は投稿できないこと" do
         item = build(:item, category_id: category[:id], preparation_day: nil)
         item.valid?
         expect(item.errors[:preparation_day]).to include("を入力してください")
       end
-      
+
       it "postageがない場合は投稿できないこと" do
         item = build(:item, category_id: category[:id], postage: nil)
         item.valid?
         expect(item.errors[:postage]).to include("を入力してください")
       end
-      
+
       it "seller_idがない場合は投稿できないこと" do
         item = build(:item, category_id: category[:id], seller_id: nil)
         item.valid?
         expect(item.errors[:seller_id]).to include("を入力してください")
       end
-      
+
       it "statusがない場合は投稿できないこと" do
         item = build(:item, category_id: category[:id], status: nil)
         item.valid?


### PR DESCRIPTION
# What
- 商品出品時、画像が0枚の時に投稿できないようバリデーションがかかるように修正
- 商品編集時、必須項目が空の場合に更新できないように修正
- ログインしていないユーザーが商品一覧・商品詳細以外のページへ行こうとしたらログインページへリダイレクトさせるよう修正
- 自身が出品した商品の購入画面へURLを直打ちしても飛べないように修正
- 一度購入された商品の購入画面へURLを直打ちしても飛べないように修正

# Why
ユーザビリティ向上・セキュリティ強化のため

![画面収録 2020-05-27 20 46 49 mov](https://user-images.githubusercontent.com/63290395/83015488-7a25ff00-a05b-11ea-85ed-59ebdae36cca.gif)
![画面収録 2020-05-27 20 45 46 mov](https://user-images.githubusercontent.com/63290395/83015493-7befc280-a05b-11ea-90cc-be99ed812d0b.gif)